### PR TITLE
Fix name of service provider under configuration section

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ By default the class `icon` is added to the icon `svg` tag when inserted into a 
 behavior by overriding the configuration using the `config/materialiconset.php` file.
 
 > A ready to use configuration file can be inserted in your config directory using 
-> `php artisan vendor:publish --provider="MaterialIcons\MaterialIconsetServiceProvider"`
+> `php artisan vendor:publish --provider="MaterialIcons\MaterialIconsBridgeServiceProvider"`
 
 You can specify any default CSS classes you'd like to be applied to your icons using the `class` option:
 


### PR DESCRIPTION
It was spotted in #14 a typo in the service provider mentioned under the _configuration_ section. 

This pull request fixes the typo when talking about the service provider to use when publishing configuration files.

Closes #14 